### PR TITLE
Add Dandelion Sprout's Game Console Ad-block List

### DIFF
--- a/.github/workflows/download-blocklists.yml
+++ b/.github/workflows/download-blocklists.yml
@@ -123,6 +123,7 @@ jobs:
           curl https://www.github.developerdan.com/hosts/lists/hate-and-junk-extended.txt --output blocklist/template/forks/developerdan.hate-and-junk-extended.txt
           curl https://www.stopforumspam.com/downloads/toxic_domains_whole.txt --output blocklist/template/forks/stopforumspam.toxic_domains_whole.txt
           curl https://zerodot1.gitlab.io/CoinBlockerLists/hosts --output blocklist/template/forks/zerodot1.CoinBlockerLists.txt
+          curl https://raw.githubusercontent.com/DandelionSprout/adfilt/master/GameConsoleAdblockList.txt
 
       - name: Use Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/download-blocklists.yml
+++ b/.github/workflows/download-blocklists.yml
@@ -123,7 +123,7 @@ jobs:
           curl https://www.github.developerdan.com/hosts/lists/hate-and-junk-extended.txt --output blocklist/template/forks/developerdan.hate-and-junk-extended.txt
           curl https://www.stopforumspam.com/downloads/toxic_domains_whole.txt --output blocklist/template/forks/stopforumspam.toxic_domains_whole.txt
           curl https://zerodot1.gitlab.io/CoinBlockerLists/hosts --output blocklist/template/forks/zerodot1.CoinBlockerLists.txt
-          curl https://raw.githubusercontent.com/DandelionSprout/adfilt/master/GameConsoleAdblockList.txt --output blocklist/template/forks/DandelionSprout.GameConsoleAdblockList.txt
+          curl https://raw.githubusercontent.com/DandelionSprout/adfilt/master/GameConsoleAdblockList.txt --output blocklist/template/ads/DandelionSprout.GameConsoleAdblockList.txt
 
       - name: Use Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/download-blocklists.yml
+++ b/.github/workflows/download-blocklists.yml
@@ -123,7 +123,7 @@ jobs:
           curl https://www.github.developerdan.com/hosts/lists/hate-and-junk-extended.txt --output blocklist/template/forks/developerdan.hate-and-junk-extended.txt
           curl https://www.stopforumspam.com/downloads/toxic_domains_whole.txt --output blocklist/template/forks/stopforumspam.toxic_domains_whole.txt
           curl https://zerodot1.gitlab.io/CoinBlockerLists/hosts --output blocklist/template/forks/zerodot1.CoinBlockerLists.txt
-          curl https://raw.githubusercontent.com/DandelionSprout/adfilt/master/GameConsoleAdblockList.txt
+          curl https://raw.githubusercontent.com/DandelionSprout/adfilt/master/GameConsoleAdblockList.txt --output blocklist/template/forks/DandelionSprout.GameConsoleAdblockList.txt
 
       - name: Use Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/download-blocklists.yml
+++ b/.github/workflows/download-blocklists.yml
@@ -123,7 +123,6 @@ jobs:
           curl https://www.github.developerdan.com/hosts/lists/hate-and-junk-extended.txt --output blocklist/template/forks/developerdan.hate-and-junk-extended.txt
           curl https://www.stopforumspam.com/downloads/toxic_domains_whole.txt --output blocklist/template/forks/stopforumspam.toxic_domains_whole.txt
           curl https://zerodot1.gitlab.io/CoinBlockerLists/hosts --output blocklist/template/forks/zerodot1.CoinBlockerLists.txt
-          curl https://raw.githubusercontent.com/DandelionSprout/adfilt/master/GameConsoleAdblockList.txt --output blocklist/template/ads/DandelionSprout.GameConsoleAdblockList.txt
 
       - name: Use Node.js
         uses: actions/setup-node@v3

--- a/blocklist/template/ads/DandelionSprout.GameConsoleAdblockList.txt
+++ b/blocklist/template/ads/DandelionSprout.GameConsoleAdblockList.txt
@@ -1,0 +1,78 @@
+[Adblock Plus 3.6]
+! Title: 🎮 Game Console Adblock List
+! Version: 19January2022v1-Alpha
+! Expires: 10 days
+! Description: Much like there's now lists for AdGuard Home and Pi-hole to block ads on smart-TVs, here's an attempt from me at doing the same for videogame consoles with AdGuard Home. Enjoy.
+! Important note: To block ads in the consoles' dedicated internet browsers with AdGuard Home, and not in the system menus, check out https://raw.githubusercontent.com/DandelionSprout/adfilt/master/AdGuard%20Home%20Compilation%20List/AdGuardHomeCompilationList.txt instead.
+! Homepage: https://github.com/DandelionSprout/adfilt/blob/master/Wiki/General-info.md#-english
+
+! ——— PlayStation 3 ———
+! Ads
+||nsx-e.np.dl.playstation.net^
+! What's New
+||mercury.dl.playstation.net^
+! PlayStation Store Preview, incl. 'My Channels' logos
+||nsx.np.dl.playstation.net^
+! Ticker ads in the XMB clockbar
+||adproxy.ndmdhs.com^
+
+! ——— Nintendo 3DS ———
+! Blocks the "Theme Shop", with the intention of preventing the annoying pink dot in the upper left of the Home Menu from reappearing all the time.
+! The entry is known to block Animal Crossing Home Designer's "Special design requests" system, although that system has been inactive since 2017.
+! WARNING: The "Theme Shop" should be visited once to remove the pink dot, and only then should this list be subscribed to.
+||npdl.cdn.nintendowifi.net^
+
+! ——— Wii U ———
+! Believed to reduce the initial loading time of Wii Sports Club by several seconds
+! Since no third-party Miiverse clients with console support are believed to be able to exist by now (January 2020), this entry is pretty much here to stay.
+||discovery.olv.nintendo.net^
+
+! ——— Xbox One ———
+! Removes sponsored info slots in the system menu
+! https://new.reddit.com/r/pihole/comments/act023/psa_block_the_sponsored_banner_ad_on_the_xbox_one/
+! Note that this also blocks Perks from Xbox Game Pass if you are subscribed to that (https://github.com/DandelionSprout/adfilt/pull/162).
+||arc.msn.com^$ctag=~device_pc|~os_windows
+
+! ——— Xbox 360 ———
+! Removes paid advertising on the Xbox Live Dashboard
+! https://www.ign.com/wikis/xbox-360/Block_Ads_on_Xbox_Live
+||rad.msn.com^
+
+! ——— Nintendo Switch ———
+! There is a system setting for getting rid of the Nintendo eShop advertisements on the lockscreen, which is hidden in System Settings → System → News Channel Settings → Nintendo News → Unfollow.
+! The following entries gives access on demand to the web browser, as per SwitchBru's DNS server trick (https://www.switchbru.com/dns/), while also making it possible to use AdGuard Home for adblocking at the same time. However, since SwitchBru uses a trick to make the Switch think it's partway into logging on to a hotel network, the entries would reject access to all other Switch web activities while the entries are live:
+!!! 45.55.142.122 ctest.cdn.nintendo.net
+!!! 127.0.0.1 receive-lp1.er.srv.nintendo.net
+!!! 127.0.0.1 aauth-lp1.ndas.srv.nintendo.net
+
+! ——— Nintendo DS / Wii ———
+! For a largely official list to connect to Wiimmfi (for DS games only) and RiiConnect24, check out https://raw.githubusercontent.com/RiiConnect24/DNS-Server/master/dns_zones-hosts.txt
+
+! ——— PlayStation 5 ———
+! I offer a €10 bounty to anyone who know how to either turn off the Explore menu tab, or prevent the Explore tab from loading any content, payable by PayPal.
+||telemetry-console.api.playstation.com^
+||telemetry-cii.api.playstation.com^
+
+! ——— PlayStation 4 ———
+! There is a system setting for getting rid of homescreen "Buy Now"-type ads, which is hidden in Settings → System → Automatic Downloads → Featured Content → Off.
+
+! ——— PlayStation 2 ———
+! I am not personally aware of any Free McBoot homebrew apps that can connect to external domains, let alone unintentionally.
+! There are multiple third-party online game servers for the PS2, most of them with flimsy websites and uptime. Popular ones include PS2 Online and Bobz Entertainment. See https://docs.google.com/spreadsheets/d/1bbxOGm4dPxZ4Vbzyu3XxBnZmuPx3Ue-cPqBeTxtnvkQ for details.
+! Any IP redirection entries for servers would've excluded one another; plus it appears that griefing was/is a very huge concern among the PS2 modding community, which I can vaguely presume is why they haven't openly revealed their DNS-server-side IP redirections.
+
+! ——— Xbox Series X/S ———
+! I offer a €15 bounty to anyone who know how to remove the sponsored ads in the main menu, payable by PayPal.
+
+! ——— Dreamcast ———
+! Although I have become aware of the existence of Dreamcast Live, I can't find the IP address redirections used by their DNS server.
+
+! ——— Steam Machines / SteamOS / Steam ———
+! To get rid of popup windows that promote new games in desktop mode, go to View → Settings → Interface → "Notify me about additions or changes to my games, new releases, and upcoming releases."
+
+! ——— Epic Games Store ———
+! To remove system notifications that promote new games and sales, go to Settings → Desktop notifications, and turn off "Show News and Special Offer Notifications" and optionally "Show Free Game Notifications"
+
+! ——— Other consoles ———
+! Entry suggestions on GitHub would be much appreciated.
+! Especially desired, since I don't own them: Sega Saturn, PlayStation Portable, PlayStation Vita, Xbox (2001 model), GameCube (https://en.wikipedia.org/wiki/GameCube_online_functionality#Supported_games), Game Boy Color/Advance (https://bulbapedia.bulbagarden.net/wiki/Mobile_System_GB#Access), PlayStation 1 (i-Mode adapter), Nintendo 64 (Randnet, Morita Shogi 64 modem), Nokia N-Gage

--- a/blocklist/template/ads/DandelionSprout.GameConsoleAdblockList.txt
+++ b/blocklist/template/ads/DandelionSprout.GameConsoleAdblockList.txt
@@ -13,7 +13,7 @@
 # Title: Block game console ads
 # Description: This blocklist is designed to prevent ads from showing in game console system menus 
 # Author: https://github.com/DandelionSprout (DandelionSprout/adfilt is licensed under the Dandelicence License)
-# Modified by: cochcoder <cochcoderContact@gmail.com>
+# Modified by: cochcoder <cochcoderContact@gmail.com>, Sefinek <contact@sefinek.net>
 # Release: <Release>
 # Version: <Version>
 # Last update: <LastUpdate>
@@ -29,64 +29,57 @@
 # If you come across any false positives, please create a new Issue or Pull request on GitHub. Thank you!
 #
 # -------------------------------------------------------------------------------------------------------------------------------------------------------
-#
-# --------------------------------------------
-# G O O D B Y E A D S  B E G I N S
-# --------------------------------------------
-! ——— PlayStation 3 ———
-! Ads
-||nsx-e.np.dl.playstation.net^
-! What's New
-||mercury.dl.playstation.net^
-! PlayStation Store Preview, incl. 'My Channels' logos
-||nsx.np.dl.playstation.net^
-! Ticker ads in the XMB clockbar
-||adproxy.ndmdhs.com^
 
-! ——— Nintendo 3DS ———
-! Blocks the "Theme Shop", with the intention of preventing the annoying pink dot in the upper left of the Home Menu from reappearing all the time.
-! The entry is known to block Animal Crossing Home Designer's "Special design requests" system, although that system has been inactive since 2017.
-! WARNING: The "Theme Shop" should be visited once to remove the pink dot, and only then should this list be subscribed to.
-||npdl.cdn.nintendowifi.net^
+# ——— PlayStation 3 ———
+0.0.0.0 nsx-e.np.dl.playstation.net # Ads
+0.0.0.0 mercury.dl.playstation.net # What's New
+0.0.0.0 nsx.np.dl.playstation.net # PlayStation Store Preview, incl. 'My Channels' logos
+0.0.0.0 adproxy.ndmdhs.com # Ticker ads in the XMB clockbar
 
-! ——— Wii U ———
-! Believed to reduce the initial loading time of Wii Sports Club by several seconds
-! Since no third-party Miiverse clients with console support are believed to be able to exist by now (January 2020), this entry is pretty much here to stay.
-||discovery.olv.nintendo.net^
+# ——— Nintendo 3DS ———
+# Blocks the "Theme Shop", with the intention of preventing the annoying pink dot in the upper left of the Home Menu from reappearing all the time.
+# The entry is known to block Animal Crossing Home Designer's "Special design requests" system, although that system has been inactive since 2017.
+# WARNING: The "Theme Shop" should be visited once to remove the pink dot, and only then should this list be subscribed to.
+0.0.0.0 npdl.cdn.nintendowifi.net
 
-! ——— Xbox One ———
-! While arc.msn.com^$ctag=~device_pc|~os_windows removes Xbox One menu ads it also removes Game Pass benefits, so add at your own discretion!
-! To add this copy and paste this on a new line: ||arc.msn.com^$ctag=~device_pc|~os_windows
+# ——— Wii U ———
+# Believed to reduce the initial loading time of Wii Sports Club by several seconds
+# Since no third-party Miiverse clients with console support are believed to be able to exist by now (January 2020), this entry is pretty much here to stay.
+0.0.0.0 discovery.olv.nintendo.net
 
-! ——— Xbox 360 ———
-! Removes paid advertising on the Xbox Live Dashboard
-! https://www.ign.com/wikis/xbox-360/Block_Ads_on_Xbox_Live
-||rad.msn.com^
+# ——— Xbox One ———
+# While arc.msn.com^$ctag=~device_pc|~os_windows removes Xbox One menu ads it also removes Game Pass benefits, so add at your own discretion!
+# To add this copy and paste this on a new line: 0.0.0.0 arc.msn.com
 
-! ——— Nintendo Switch ———
-! There is a system setting for getting rid of the Nintendo eShop advertisements on the lockscreen, which is hidden in System Settings → System → News Channel Settings → Nintendo News → Unfollow.
-! The following entries gives access on demand to the web browser, as per SwitchBru's DNS server trick (https://www.switchbru.com/dns/), while also making it possible to use AdGuard Home for adblocking at the same time. However, since SwitchBru uses a trick to make the Switch think it's partway into logging on to a hotel network, the entries would reject access to all other Switch web activities while the entries are live:
-!!! 45.55.142.122 ctest.cdn.nintendo.net
-!!! 127.0.0.1 receive-lp1.er.srv.nintendo.net
-!!! 127.0.0.1 aauth-lp1.ndas.srv.nintendo.net
+# ——— Xbox 360 ———
+# Removes paid advertising on the Xbox Live Dashboard
+# https://www.ign.com/wikis/xbox-360/Block_Ads_on_Xbox_Live
+0.0.0.0 rad.msn.com
 
-! ——— Nintendo DS / Wii ———
-! For a largely official list to connect to Wiimmfi (for DS games only) and RiiConnect24, check out https://raw.githubusercontent.com/RiiConnect24/DNS-Server/master/dns_zones-hosts.txt
+# ——— Nintendo Switch ———
+# There is a system setting for getting rid of the Nintendo eShop advertisements on the lockscreen, which is hidden in System Settings → System → News Channel Settings → Nintendo News → Unfollow.
+# The following entries gives access on demand to the web browser, as per SwitchBru's DNS server trick (https://www.switchbru.com/dns), while also making it possible to use AdGuard Home for adblocking at the same time. However, since SwitchBru uses a trick to make the Switch think it's partway into logging on to a hotel network, the entries would reject access to all other Switch web activities while the entries are live:
+## 0.0.0.0 ctest.cdn.nintendo.net
+## 0.0.0.0 receive-lp1.er.srv.nintendo.net
+## 0.0.0.0 aauth-lp1.ndas.srv.nintendo.net
 
-! ——— PlayStation 5 ———
-||telemetry-console.api.playstation.com^
-||telemetry-cii.api.playstation.com^
+# ——— Nintendo DS / Wii ———
+# For a largely official list to connect to Wiimmfi (for DS games only) and RiiConnect24, check out https://raw.githubusercontent.com/RiiConnect24/DNS-Server/master/dns_zones-hosts.txt
 
-! ——— PlayStation 4 ———
-! There is a system setting for getting rid of homescreen "Buy Now"-type ads, which is hidden in Settings → System → Automatic Downloads → Featured Content → Off.
+# ——— PlayStation 5 ———
+0.0.0.0 telemetry-console.api.playstation.com
+0.0.0.0 telemetry-cii.api.playstation.com
 
-! ——— PlayStation 2 ———
-! I am not personally aware of any Free McBoot homebrew apps that can connect to external domains, let alone unintentionally.
-! There are multiple third-party online game servers for the PS2, most of them with flimsy websites and uptime. Popular ones include PS2 Online and Bobz Entertainment. See https://docs.google.com/spreadsheets/d/1bbxOGm4dPxZ4Vbzyu3XxBnZmuPx3Ue-cPqBeTxtnvkQ for details.
-! Any IP redirection entries for servers would've excluded one another; plus it appears that griefing was/is a very huge concern among the PS2 modding community, which I can vaguely presume is why they haven't openly revealed their DNS-server-side IP redirections.
+# ——— PlayStation 4 ———
+# There is a system setting for getting rid of homescreen "Buy Now"-type ads, which is hidden in Settings → System → Automatic Downloads → Featured Content → Off.
 
-! ——— Steam Machines / SteamOS / Steam ———
-! To get rid of popup windows that promote new games in desktop mode, go to View → Settings → Interface → "Notify me about additions or changes to my games, new releases, and upcoming releases."
+# ——— PlayStation 2 ———
+# I am not personally aware of any Free McBoot homebrew apps that can connect to external domains, let alone unintentionally.
+# There are multiple third-party online game servers for the PS2, most of them with flimsy websites and uptime. Popular ones include PS2 Online and Bobz Entertainment. See https://docs.google.com/spreadsheets/d/1bbxOGm4dPxZ4Vbzyu3XxBnZmuPx3Ue-cPqBeTxtnvkQ for details.
+# Any IP redirection entries for servers would've excluded one another; plus it appears that griefing was/is a very huge concern among the PS2 modding community, which I can vaguely presume is why they haven't openly revealed their DNS-server-side IP redirections.
 
-! ——— Epic Games Store ———
-! To remove system notifications that promote new games and sales, go to Settings → Desktop notifications, and turn off "Show News and Special Offer Notifications" and optionally "Show Free Game Notifications"
+# ——— Steam Machines / SteamOS / Steam ———
+# To get rid of popup windows that promote new games in desktop mode, go to View → Settings → Interface → "Notify me about additions or changes to my games, new releases, and upcoming releases."
+
+# ——— Epic Games Store ———
+# To remove system notifications that promote new games and sales, go to Settings → Desktop notifications, and turn off "Show News and Special Offer Notifications" and optionally "Show Free Game Notifications"

--- a/blocklist/template/ads/DandelionSprout.GameConsoleAdblockList.txt
+++ b/blocklist/template/ads/DandelionSprout.GameConsoleAdblockList.txt
@@ -13,7 +13,7 @@
 # Title: Block game console ads
 # Description: This blocklist is designed to prevent ads from showing in game console system menus 
 # Author: https://github.com/DandelionSprout (DandelionSprout/adfilt is licensed under the Dandelicence License)
-# Modified by: cochcoder <contact@sefinek.net>
+# Modified by: cochcoder <cochcoderContact@gmail.com>
 # Release: <Release>
 # Version: <Version>
 # Last update: <LastUpdate>

--- a/blocklist/template/ads/DandelionSprout.GameConsoleAdblockList.txt
+++ b/blocklist/template/ads/DandelionSprout.GameConsoleAdblockList.txt
@@ -1,11 +1,38 @@
-[Adblock Plus 3.6]
-! Title: 🎮 Game Console Adblock List
-! Version: 19January2022v1-Alpha
-! Expires: 10 days
-! Description: Much like there's now lists for AdGuard Home and Pi-hole to block ads on smart-TVs, here's an attempt from me at doing the same for videogame consoles with AdGuard Home. Enjoy.
-! Important note: To block ads in the consoles' dedicated internet browsers with AdGuard Home, and not in the system menus, check out https://raw.githubusercontent.com/DandelionSprout/adfilt/master/AdGuard%20Home%20Compilation%20List/AdGuardHomeCompilationList.txt instead.
-! Homepage: https://github.com/DandelionSprout/adfilt/blob/master/Wiki/General-info.md#-english
-
+#-------------------------------------------------------------------------------------------------------------------------------------------------------
+#
+#       _____   ______   ______   _____   _   _   ______   _  __        ____    _         ____     _____   _  __  _        _____    _____   _______
+#      / ____| |  ____| |  ____| |_   _| | \ | | |  ____| | |/ /       |  _ \  | |       / __ \   / ____| | |/ / | |      |_   _|  / ____| |__   __|
+#     | (___   | |__    | |__      | |   |  \| | | |__    | ' /        | |_) | | |      | |  | | | |      | ' /  | |        | |   | (___      | |
+#      \___ \  |  __|   |  __|     | |   | . ` | |  __|   |  <         |  _ <  | |      | |  | | | |      |  <   | |        | |    \___ \     | |
+#      ____) | | |____  | |       _| |_  | |\  | | |____  | . \        | |_) | | |____  | |__| | | |____  | . \  | |____   _| |_   ____) |    | |
+#     |_____/  |______| |_|      |_____| |_| \_| |______| |_|\_\       |____/  |______|  \____/   \_____| |_|\_\ |______| |_____| |_____/     |_|
+#
+#                                   The best collection of blocklists for Pi-hole and AdGuard - https://sefinek.net
+#                                            https://github.com/sefinek24/PiHole-Blocklist-Collection
+#
+# Title: Block game console ads
+# Description: This blocklist is designed to prevent ads from showing in game console system menus 
+# Author: https://github.com/DandelionSprout (DandelionSprout/adfilt is licensed under the Dandelicence License)
+# Modified by: cochcoder <contact@sefinek.net>
+# Release: <Release>
+# Version: <Version>
+# Last update: <LastUpdate>
+#
+# 〢 Important:
+# This list does not block ads in the consoles' dedicated internet browsers this only blocks ads in the consoles' system menus. 
+#
+# 〢 Warning:
+# By using this file, you acknowledge that the author is not liable for any damages or losses that may arise from its use, although the likelihood of such events is low.
+#
+# 〢 About:
+# This file is part of the Sefinek's Blocklist Collection, maintained by github.com/sefinek24.
+# If you come across any false positives, please create a new Issue or Pull request on GitHub. Thank you!
+#
+# -------------------------------------------------------------------------------------------------------------------------------------------------------
+#
+# --------------------------------------------
+# G O O D B Y E A D S  B E G I N S
+# --------------------------------------------
 ! ——— PlayStation 3 ———
 ! Ads
 ||nsx-e.np.dl.playstation.net^
@@ -28,10 +55,8 @@
 ||discovery.olv.nintendo.net^
 
 ! ——— Xbox One ———
-! Removes sponsored info slots in the system menu
-! https://new.reddit.com/r/pihole/comments/act023/psa_block_the_sponsored_banner_ad_on_the_xbox_one/
-! Note that this also blocks Perks from Xbox Game Pass if you are subscribed to that (https://github.com/DandelionSprout/adfilt/pull/162).
-||arc.msn.com^$ctag=~device_pc|~os_windows
+! While arc.msn.com^$ctag=~device_pc|~os_windows removes Xbox One menu ads it also removes Game Pass benefits, so add at your own discretion!
+! To add this copy and paste this on a new line: ||arc.msn.com^$ctag=~device_pc|~os_windows
 
 ! ——— Xbox 360 ———
 ! Removes paid advertising on the Xbox Live Dashboard
@@ -49,7 +74,6 @@
 ! For a largely official list to connect to Wiimmfi (for DS games only) and RiiConnect24, check out https://raw.githubusercontent.com/RiiConnect24/DNS-Server/master/dns_zones-hosts.txt
 
 ! ——— PlayStation 5 ———
-! I offer a €10 bounty to anyone who know how to either turn off the Explore menu tab, or prevent the Explore tab from loading any content, payable by PayPal.
 ||telemetry-console.api.playstation.com^
 ||telemetry-cii.api.playstation.com^
 
@@ -61,18 +85,8 @@
 ! There are multiple third-party online game servers for the PS2, most of them with flimsy websites and uptime. Popular ones include PS2 Online and Bobz Entertainment. See https://docs.google.com/spreadsheets/d/1bbxOGm4dPxZ4Vbzyu3XxBnZmuPx3Ue-cPqBeTxtnvkQ for details.
 ! Any IP redirection entries for servers would've excluded one another; plus it appears that griefing was/is a very huge concern among the PS2 modding community, which I can vaguely presume is why they haven't openly revealed their DNS-server-side IP redirections.
 
-! ——— Xbox Series X/S ———
-! I offer a €15 bounty to anyone who know how to remove the sponsored ads in the main menu, payable by PayPal.
-
-! ——— Dreamcast ———
-! Although I have become aware of the existence of Dreamcast Live, I can't find the IP address redirections used by their DNS server.
-
 ! ——— Steam Machines / SteamOS / Steam ———
 ! To get rid of popup windows that promote new games in desktop mode, go to View → Settings → Interface → "Notify me about additions or changes to my games, new releases, and upcoming releases."
 
 ! ——— Epic Games Store ———
 ! To remove system notifications that promote new games and sales, go to Settings → Desktop notifications, and turn off "Show News and Special Offer Notifications" and optionally "Show Free Game Notifications"
-
-! ——— Other consoles ———
-! Entry suggestions on GitHub would be much appreciated.
-! Especially desired, since I don't own them: Sega Saturn, PlayStation Portable, PlayStation Vita, Xbox (2001 model), GameCube (https://en.wikipedia.org/wiki/GameCube_online_functionality#Supported_games), Game Boy Color/Advance (https://bulbapedia.bulbagarden.net/wiki/Mobile_System_GB#Access), PlayStation 1 (i-Mode adapter), Nintendo 64 (Randnet, Morita Shogi 64 modem), Nokia N-Gage

--- a/lists/other/Modified lists.md
+++ b/lists/other/Modified lists.md
@@ -25,7 +25,7 @@ The blocklists were modified to improve their effectiveness and to ensure they d
 
 ### DandelionSprout/adfilt
 1. https://raw.githubusercontent.com/DandelionSprout/adfilt/master/GameConsoleAdblockList.txt
-   - **Modified version:** #https://blocklist.sefinek.net/generated/0.0.0.0/ads/DandelionSprout.GameConsoleAdblockList.txt
+   - **Modified version:** https://blocklist.sefinek.net/generated/0.0.0.0/ads/DandelionSprout.GameConsoleAdblockList.txt
    - **Added:** No additional domains have been added to this blocklist. A warning for `arc.msn.com` explaining why it was removed and how you can add it have been added.
    - **Removed:**
    The `arc.msn.com` domain has been removed from the list as it is necessary to receive benefits from Xbox Game Pass. Bounties for ads have been also removed, see original list for bounty infomation. 

--- a/lists/other/Modified lists.md
+++ b/lists/other/Modified lists.md
@@ -25,10 +25,10 @@ The blocklists were modified to improve their effectiveness and to ensure they d
 
 ### DandelionSprout/adfilt
 1. https://raw.githubusercontent.com/DandelionSprout/adfilt/master/GameConsoleAdblockList.txt
-   - **Modified version:** #https://blocklist.sefinek.net/generated/0.0.0.0/ads/TheBlockListProject.AdsList.txt
-   - **Added:** No additional domains have been added to this blocklist.
+   - **Modified version:** #https://blocklist.sefinek.net/generated/0.0.0.0/ads/DandelionSprout.GameConsoleAdblockList.txt
+   - **Added:** No additional domains have been added to this blocklist. A warning for `arc.msn.com` explaining why it was removed and how you can add it have been added.
    - **Removed:**
-   The `arc.msn.com` domain has been removed from the list as it is necessary to receive benefits from Xbox Game Pass.
+   The `arc.msn.com` domain has been removed from the list as it is necessary to receive benefits from Xbox Game Pass. Bounties for ads have been also removed, see original list for bounty infomation. 
 
 <!--
 ### jerryn70/GoodbyeAds

--- a/lists/other/Modified lists.md
+++ b/lists/other/Modified lists.md
@@ -22,6 +22,14 @@ The blocklists were modified to improve their effectiveness and to ensure they d
    - **Removed:**
    The `arc.msn.com` domain has been removed from the list as it is necessary to receive benefits from Xbox Game Pass.
 
+
+### DandelionSprout/adfilt
+1. https://raw.githubusercontent.com/DandelionSprout/adfilt/master/GameConsoleAdblockList.txt
+   - **Modified version:** #https://blocklist.sefinek.net/generated/0.0.0.0/ads/TheBlockListProject.AdsList.txt
+   - **Added:** No additional domains have been added to this blocklist.
+   - **Removed:**
+   The `arc.msn.com` domain has been removed from the list as it is necessary to receive benefits from Xbox Game Pass.
+
 <!--
 ### jerryn70/GoodbyeAds
 - **Modified version:** https://github.com/sefinek24/PiHole-Blocklist-Collection/blob/main/blocklist/GoodbyeAds.txt


### PR DESCRIPTION
Dandelion Sprout's Game Console Ad-block List contains ad domains that are not in the other lists. The only false positive I have noticed from this list is arc.msn.com. Which is only an issue if you have Game Pass. 